### PR TITLE
Updates in Oss, Webhooks and DataManagement yamls

### DIFF
--- a/datamanagement/datamanagement.yaml
+++ b/datamanagement/datamanagement.yaml
@@ -3677,6 +3677,15 @@ components:
       description: Properties of an item.
       title: 'Item Attributes:'
       type: object
+      required:
+        - displayName
+        - createTime
+        - createUserId
+        - createUserName
+        - lastModifiedTime
+        - lastModifiedUserId
+        - lastModifiedUserName
+        - extension
       properties:
         displayName:
           type: string
@@ -3734,15 +3743,11 @@ components:
           description: The name of the user who reserved the item.
         extension:
           $ref: '#/components/schemas/item_extension_with_schema_link'
-      required:
-        - displayName
-        - createTime
-        - createUserId
-        - createUserName
-        - lastModifiedTime
-        - lastModifiedUserId
-        - lastModifiedUserName
-        - extension
+        pathInProject:
+          type: string
+          x-stoplight:
+            id: weoan682ts8ft
+          description: The relative path of the item starting from project’s root folder.
     ModifyItemPayload:
       description: An object that defines the attributes of an item that must be updated.
       x-stoplight:

--- a/oss/oss.yaml
+++ b/oss/oss.yaml
@@ -1087,7 +1087,10 @@ paths:
       responses:
         '200':
           description: Upload successfully completed
-          content: {}
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/objectDetails'
         '400':
           $ref: '#/components/responses/BAD_REQUEST'
         '401':
@@ -1260,7 +1263,8 @@ components:
           type: string
           description: The Client ID of the application that owns the bucket.
         createdDate:
-          type: string
+          type: integer
+          format: int64
           description: 'The time the bucket was created, represented as a Unix timestamp.'
         permissions:
           type: array

--- a/webhooks/webhooks.yaml
+++ b/webhooks/webhooks.yaml
@@ -1044,6 +1044,8 @@ components:
         - adsk.c4r
         - adsk.flc.production
         - autodesk.construction.cost
+        - autodesk.construction.bc
+        - autodesk.construction.issues
       title: SystemEnum
       default: data
     Events:
@@ -1126,6 +1128,17 @@ components:
         - sco.created-1.0
         - sco.updated-1.0
         - sco.deleted-1.0
+        - bid.created
+        - opportunity.comment.created
+        - opportunity.comment.deleted
+        - opportunity.comment.updated
+        - opportunity.created
+        - opportunity.status.updated
+        - issue.created-1.0
+        - issue.updated-1.0
+        - issue.deleted-1.0
+        - issue.restored-1.0
+        - issue.unlinked-1.0
     Scopes:
       type: string
       x-stoplight:


### PR DESCRIPTION
DataManagement 
- Added the missing pathInProject parameter in ItemAttributes object

OSS 
- updated "createdDate" attribute in response object for bucket creation from string to int64 (#14)
- added response object for Complete Upload to S3 Signed URL(#12)

Webhooks
- updated webhooks events with the new Acc Issues and BuildingConnected enum values